### PR TITLE
fixing Tiles Parameters not showing textures in some cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ qrc_*.cpp
 ui_*.h
 Makefile*
 *build-*
-
+build
 
 # Qt unit tests
 target_wrapper.*

--- a/landscape.cpp
+++ b/landscape.cpp
@@ -124,6 +124,11 @@ bool CLandscape::serializeMpr(const QString& zoneName, CResFile& mprFile)
     return true;
 }
 
+QString CLandscape::mapName() const
+{
+    return m_map_name;
+}
+
 // Generates sector suffix by number: 001002 - sector x:1 y:2
 QString genSectorSuffix(int x, int y)
 {
@@ -168,6 +173,8 @@ void CLandscape::readMap(const QFileInfo& path)
         if(fName.endsWith(".mp"))
             innerMapName = fName.split(".").front(); //todo: dont split multiple dot names (zone.1.gipath.mp)
     }
+    //in some cases map has diffrent name then file name so we need this inner mp name
+    m_map_name = innerMapName;
 
     int texCount;
     m_texture = CTextureList::getInstance()->buildLandTex(innerMapName, texCount);

--- a/landscape.h
+++ b/landscape.h
@@ -84,6 +84,8 @@ public:
     void setDirty(bool bDirty) {m_bDirty = bDirty;}
     bool isDirty() const {return m_bDirty;}
 
+    QString mapName() const;
+
 private:
     CLandscape();
     ~CLandscape();
@@ -100,6 +102,7 @@ private:
     QOpenGLTexture* m_texture;
     QFileInfo m_filePath;
     QVector<int> m_arrIncorectTiles;
+    QString m_map_name;
     bool m_bDirty;
 };
 

--- a/layout_components/tablemanager.h
+++ b/layout_components/tablemanager.h
@@ -10,6 +10,10 @@
 #include <QLineEdit>
 #include <QStringListModel>
 
+
+#include <QEvent>
+#include <QKeyEvent>
+
 #include "types.h"
 #include "undo.h"
 #include "property.h"

--- a/main_window.cpp
+++ b/main_window.cpp
@@ -485,3 +485,4 @@ void MainWindow::on_actionSave_landscape_MPR_triggered()
     m_pView->saveLand();
 }
 
+

--- a/view.cpp
+++ b/view.cpp
@@ -732,7 +732,7 @@ void CView::drawTilePreview(QOpenGLShaderProgram* program)
 void CView::updateTileForm(bool bGenerateNewTable)
 {
     if(bGenerateNewTable)
-        m_pTileForm->fillTable(m_pLand->filePath().baseName(), m_pLand->textureNum());
+        m_pTileForm->fillTable(m_pLand->mapName(), m_pLand->textureNum());
     m_pTileForm->setTileTypes(m_pLand->tileTypes());
     m_pTileForm->setMaterial(m_pLand->materials());
     m_pTileForm->setAnimTile(m_pLand->animTiles());


### PR DESCRIPTION
After loading map form mod [ei universal mod](https://github.com/Kyr4l/ei-universal-mod) in zone 5 map is not showing anything in Tiles Parameters window.
It looks like textures name starts with Zone5_1 (mp file in Zone5.mpr is Zone5_1.MP) so I added private variable m_map_name to CLandscape, and getter to access this value.

For some reason without this 2 includes in **ei_maper\layout_components\tablemanager.h** I couldn't compile on Windows.
```
#include <QEvent>
#include <QKeyEvent>

```



In this PR I added build folder to git ignore, using qtcreator on windows create build folder in source so i think it will be a good idea to have it.